### PR TITLE
Added support for ptpython's IPython prompt start.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,32 @@ to avoid consuming too wide space by REPL.
 `b:reply_termwin_max_height` and `b:reply_termwin_max_width` are buffer-local version of the
 variables.
 
+### `b:reply_ptpython_prompt_start`
+
+- Type: `string`
+- Default value: undefined
+
+The ptpython REPL can have differet prompt starts depeding on your ptpython config.py. 
+
+This can cause the `ReplRecv` command to fail, as it depends on the prompt start.
+
+To avoid this issue, ptpython users should set `b:reply_ptpython_prompt_start`. 
+
+If you only use the REPL while editing python files, then I'd reccomend setting it in `ftplugin/python.vim`.
+
+If you want to be able to use the ptpython REPL with any filetype, then I'd set it in your `.vimrc`
+
+If you use the 'classic' prompt start, then:
+
+```vim
+let b:reply_ptpython_prompt_start = "classic"
+```
+
+If you use the 'ipython' prompt start, then:
+
+```vim
+let b:reply_ptpython_prompt_start = "classic"
+```
 
 ## License
 

--- a/autoload/reply/repl/ptpython.vim
+++ b/autoload/reply/repl/ptpython.vim
@@ -1,6 +1,13 @@
 function! reply#repl#ptpython#new() abort
+  if b:reply_ptpyton_prompt_start ==? "ipython"
     return reply#repl#base('ptpython', {
-        \   'prompt_start' : '\vIn [[0-9]*]: ',
-        \   'prompt_continue' : '^\.\.\. ',
-        \ })
+      \   'prompt_start' : '\vIn [[0-9]*]: ',
+      \   'prompt_continue' : '^\.\.\. ',
+      \ })
+  else
+    return reply#repl#base('ptpython', {
+      \   'prompt_start' : '^>>> ',
+      \   'prompt_continue' : '^\.\.\. ',
+      \ })
+  endif
 endfunction

--- a/autoload/reply/repl/ptpython.vim
+++ b/autoload/reply/repl/ptpython.vim
@@ -1,6 +1,6 @@
 function! reply#repl#ptpython#new() abort
     return reply#repl#base('ptpython', {
-        \   'prompt_start' : '^>>> ',
+        \   'prompt_start' : '\vIn [[0-9]*]: ',
         \   'prompt_continue' : '^\.\.\. ',
         \ })
 endfunction


### PR DESCRIPTION
Added `b:reply_ptpython_prompt_start` variable. If it is unset, then reply.vim expects ptpython classic prompt start - the more likely case. If a user set this variable to "ipython", either in `.vimrc` or `ftplugin/python.vim`, then reply.vim will expect the IPython prompt start.

ptpython prompt start is set in the user's `~/.ptpython/config.py`.

Closes #4.
