### PR TITLE
add scala `sbt test:console` repl

### DIFF
--- a/autoload/reply/lifecycle.vim
+++ b/autoload/reply/lifecycle.vim
@@ -19,7 +19,7 @@ let s:default_repls = {
 \   'zsh': ['zsh'],
 \   'julia': ['julia'],
 \   'crystal': ['icr'],
-\   'scala': ['scala'],
+\   'scala': ['sbt_console', 'scala'],
 \   'kotlin': ['kotlinc'],
 \   'clojure': ['clojure'],
 \   'java': ['jshell'],

--- a/autoload/reply/repl/sbt_console.vim
+++ b/autoload/reply/repl/sbt_console.vim
@@ -5,7 +5,7 @@ function! s:repl.executable() abort
 endfunction
 
 function! s:repl.is_available() abort
-  return executable(self.executable()) && !empty(glob("./build.sbt"))
+  return executable(self.executable()) && filereadable("./build.sbt")
 endfunction
 
 function! s:repl.get_command() abort

--- a/autoload/reply/repl/sbt_console.vim
+++ b/autoload/reply/repl/sbt_console.vim
@@ -1,0 +1,17 @@
+let s:repl = reply#repl#base('sbt test:console')
+
+function! s:repl.executable() abort
+  return "sbt"
+endfunction
+
+function! s:repl.is_available() abort
+  return executable(self.executable()) && !empty(glob("./build.sbt"))
+endfunction
+
+function! s:repl.get_command() abort
+    return [self.executable(), 'test:console'] + self.get_var('command_options', [])
+endfunction
+
+function! reply#repl#sbt_console#new() abort
+    return deepcopy(s:repl)
+endfunction


### PR DESCRIPTION
Repl for scala [sbt](https://www.scala-sbt.org/index.html) projects. I suppose it should be convenient to run `sbt` as default repl if `./build.sbt` is detected. 