### PR TITLE
Ignores help tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
When installing reply.vim as a git submodule, running `:helptags` on reply.vim leaves the submodule in an unclean state. To avoid this, add the generated `doc/tags` file to the `.gitignore`.